### PR TITLE
check mounted before setState

### DIFF
--- a/lib/src/carousel_slider.dart
+++ b/lib/src/carousel_slider.dart
@@ -142,6 +142,7 @@ class _CarouselSliderState extends State<CarouselSlider> {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       // After the first build method, request a redraw
+      if (!mounted) return;
       setState(() {});
     });
 


### PR DESCRIPTION
carousel UIのリストの画面を高速にスクロールした場合に以下のExceptionが発生するのでその修正です
```
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ setState() called after dispose(): _CarouselSliderState#098a1(lifecycle state: defunct, not mounted)
│ This error happens if you call setState() on a State object for a widget that no longer appears in the widget tree (e.g., whose parent widget no longer includes the widget in its build). This error can occur when code calls setState() from a timer or an animation callback.
│ The preferred solution is to cancel the timer or stop listening to the animation in the dispose() callback. Another solution is to check the "mounted" property of this object before calling setState() to ensure the object is still in the tree.
│ This error might indicate a memory leak if setState() is being called because another object is retaining a reference to this State object after it has been removed from the tree. To avoid memory leaks, consider breaking the reference to this object during dispose().
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ #0   packages/flutter/src/widgets/framework.dart 1167:9                                <fn>
│ #1   packages/flutter/src/widgets/framework.dart 1201:14                               setState
│ #2   packages/carousel_slider_x/src/carousel_slider.dart 145:7                         <fn>
│ #3   packages/flutter/src/scheduler/binding.dart 1386:7                                [_invokeFrameCallback]
│ #4   packages/flutter/src/scheduler/binding.dart 1322:11                               handleDrawFrame
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ Exception
└───────────────
```