### PR TITLE
fix : set initialPage to _currentPage

### DIFF
--- a/lib/src/carousel_slider.dart
+++ b/lib/src/carousel_slider.dart
@@ -301,6 +301,7 @@ class _CarouselSliderState extends State<CarouselSlider> {
       viewportFraction: _options.viewportFraction,
       initialPage: initialPage,
     );
+    _currentPage = initialPage.toDouble();
     _pageController.addListener(() {
       _currentPage = _pageController.page;
       widget.onScrolled?.call(_currentPage);


### PR DESCRIPTION
- 初期表示時には_pageController.addListener内が呼ばれずに_currentPageがnullになっていそう？
   - https://github.com/koji-1009/flutter_carousel_slider/blob/main/lib/src/carousel_slider.dart#L305
- その状態で_pageController.animateToPageが呼ばれた場合は以下の箇所で`Null check operator used on a null value`が発生
   - https://github.com/koji-1009/flutter_carousel_slider/blob/main/lib/src/carousel_slider.dart#L357