### PR TITLE
Fix README sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ CarouselSlider(
     height: 400,
   ),
   items: [1,2,3,4,5].map((i) {
-    Container(
+    return Container(
       width: MediaQuery.sizeOf(context).width,
       margin: EdgeInsets.symmetric(
-        horizontal: 8.
+        horizontal: 8.0
       ),
       decoration: BoxDecoration(
         color: Colors.amber
@@ -59,7 +59,7 @@ CarouselSlider(
         ),
       ),
     );
-  }.toList(),
+  }).toList(),
 )
 ```
 


### PR DESCRIPTION
## Summary

Fixed the sample code in the "How to use" section of the README because it was not functional as written.

## What changed

* Added missing return statement in the sample code's map callback
* Fixed incomplete decimal number (8. → 8.0)
* Fixed missing closing parenthesis in the map function (}.toList() → }).toList())

## Why

The current sample code in the README contains syntax errors that prevent it from compiling. Since users trying the library for the first time by copying and pasting might get confused, I have implemented these fixes.

## How tested

This change only affects the README and does not impact the source code.
The updated snippet was copied into a sample project and confirmed to compile successfully.