### PR TITLE
fix: animateToClosest backward wrap bug and add comprehensive tests

### DIFF
--- a/lib/src/carousel_slider.dart
+++ b/lib/src/carousel_slider.dart
@@ -382,9 +382,10 @@ class _CarouselSliderState extends State<CarouselSlider> {
         if (_options.enableInfiniteScroll && _options.animateToClosest) {
           final distance = (page - index).abs();
           final distanceWithNext = (page + widget.itemCount - index).abs();
+          final distanceWithPrev = (page - widget.itemCount - index).abs();
           if (distance > distanceWithNext) {
             smallestMovement = page + widget.itemCount - index;
-          } else if (distance > distanceWithNext) {
+          } else if (distance > distanceWithPrev) {
             smallestMovement = page - widget.itemCount - index;
           }
         }

--- a/test/carousel_slider_test.dart
+++ b/test/carousel_slider_test.dart
@@ -813,8 +813,7 @@ void main() {
   });
 
   group('animateToClosest option', () {
-    testWidgets('when false, does not search for closest path',
-        (tester) async {
+    testWidgets('when false, does not search for closest path', (tester) async {
       final controller = CarouselControllerX();
 
       await tester.pumpWidget(
@@ -844,8 +843,7 @@ void main() {
       expect(find.text('4'), findsOneWidget);
     });
 
-    testWidgets(
-        'when true, chooses backward wrap when it is the shortest path',
+    testWidgets('when true, chooses backward wrap when it is the shortest path',
         (tester) async {
       // Regression: duplicate condition bug caused backward wrap to never
       // be selected. With 10 items at page 1, animateToPage(9) should go
@@ -884,8 +882,7 @@ void main() {
   });
 
   group('Enlarge Strategies', () {
-    testWidgets('Scale strategy renders with Transform.scale',
-        (tester) async {
+    testWidgets('Scale strategy renders with Transform.scale', (tester) async {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -909,8 +906,7 @@ void main() {
 
       // Center item (Item 1) should exist with Transform
       final item1TransformFinder = find
-          .ancestor(
-              of: find.text('Item 1'), matching: find.byType(Transform))
+          .ancestor(of: find.text('Item 1'), matching: find.byType(Transform))
           .first;
       final transform1 = tester.widget<Transform>(item1TransformFinder);
       final scale1 = transform1.transform.storage[0];

--- a/test/carousel_slider_test.dart
+++ b/test/carousel_slider_test.dart
@@ -1,4 +1,5 @@
 import 'package:carousel_slider_x/carousel_slider_x.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -542,6 +543,814 @@ void main() {
       expect(scale1, closeTo(1.0, 0.01),
           reason: 'Center item should be full scale');
       expect(scale0, lessThan(0.95), reason: 'Side item should be scaled down');
+    });
+  });
+
+  group('onScrolled callback', () {
+    testWidgets('is called during scroll', (tester) async {
+      final positions = <double>[];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CarouselSlider(
+              options: const CarouselOptions(
+                viewportFraction: 1.0,
+                enableInfiniteScroll: false,
+              ),
+              onScrolled: (position) {
+                positions.add(position);
+              },
+              items: const [
+                Text('Item 1'),
+                Text('Item 2'),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      await tester.fling(find.text('Item 1'), const Offset(-500, 0), 2000);
+      await tester.pumpAndSettle();
+
+      expect(positions, isNotEmpty);
+    });
+
+    testWidgets('is called via controller navigation', (tester) async {
+      final controller = CarouselControllerX();
+      final positions = <double>[];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CarouselSlider(
+              carouselController: controller,
+              options: const CarouselOptions(
+                viewportFraction: 1.0,
+                enableInfiniteScroll: false,
+              ),
+              onScrolled: (position) {
+                positions.add(position);
+              },
+              items: const [
+                Text('Item 1'),
+                Text('Item 2'),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      controller.nextPage();
+      await tester.pumpAndSettle();
+
+      expect(positions, isNotEmpty);
+    });
+  });
+
+  group('disableGesture', () {
+    testWidgets('when true, prevents swipe navigation', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CarouselSlider(
+              options: const CarouselOptions(
+                viewportFraction: 1.0,
+                enableInfiniteScroll: false,
+                disableGesture: true,
+              ),
+              items: const [
+                Text('Item 1'),
+                Text('Item 2'),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Item 1'), findsOneWidget);
+
+      // GestureDetector should not be present
+      expect(
+        find.ancestor(
+          of: find.byType(PageView),
+          matching: find.byType(GestureDetector),
+        ),
+        findsNothing,
+      );
+    });
+
+    testWidgets('when false, GestureDetector is present', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CarouselSlider(
+              options: const CarouselOptions(
+                viewportFraction: 1.0,
+                enableInfiniteScroll: false,
+                disableGesture: false,
+              ),
+              items: const [
+                Text('Item 1'),
+                Text('Item 2'),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      expect(
+        find.ancestor(
+          of: find.byType(PageView),
+          matching: find.byType(GestureDetector),
+        ),
+        findsOneWidget,
+      );
+    });
+  });
+
+  group('pauseAutoPlayOnTouch', () {
+    testWidgets('pauses auto play during touch when enabled', (tester) async {
+      int pageChanges = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CarouselSlider(
+              options: const CarouselOptions(
+                autoPlay: true,
+                autoPlayInterval: Duration(seconds: 1),
+                autoPlayAnimationDuration: Duration(milliseconds: 200),
+                viewportFraction: 1.0,
+                enableInfiniteScroll: true,
+                pauseAutoPlayOnTouch: true,
+              ),
+              onPageChanged: (index, reason) {
+                pageChanges++;
+              },
+              items: const [
+                Text('Item 1'),
+                Text('Item 2'),
+                Text('Item 3'),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      // Simulate touch down (pan down) to pause auto play
+      final gesture = await tester.startGesture(
+        tester.getCenter(find.text('Item 1')),
+        kind: PointerDeviceKind.touch,
+      );
+
+      // Wait longer than autoPlayInterval while touch is held
+      await tester.pump(const Duration(seconds: 2));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      final changesWhileTouching = pageChanges;
+
+      // Release touch
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      // After release, auto play should resume
+      await tester.pump(const Duration(seconds: 1));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // Should have auto-played after release
+      expect(pageChanges, greaterThan(changesWhileTouching));
+    });
+  });
+
+  group('pauseAutoPlayInFiniteScroll', () {
+    testWidgets('pauses at last item when true', (tester) async {
+      int lastPageIndex = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CarouselSlider(
+              options: const CarouselOptions(
+                autoPlay: true,
+                autoPlayInterval: Duration(seconds: 1),
+                autoPlayAnimationDuration: Duration(milliseconds: 200),
+                viewportFraction: 1.0,
+                enableInfiniteScroll: false,
+                pauseAutoPlayInFiniteScroll: true,
+              ),
+              onPageChanged: (index, reason) {
+                lastPageIndex = index;
+              },
+              items: const [
+                Text('Item 1'),
+                Text('Item 2'),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      // Auto play to last item (Item 2)
+      await tester.pump(const Duration(seconds: 1));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(lastPageIndex, 1);
+
+      // Wait another interval - should NOT wrap to Item 1
+      await tester.pump(const Duration(seconds: 2));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // Should still be on last item
+      expect(find.text('Item 2'), findsOneWidget);
+    });
+
+    testWidgets('wraps to first item when false', (tester) async {
+      int lastPageIndex = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CarouselSlider(
+              options: const CarouselOptions(
+                autoPlay: true,
+                autoPlayInterval: Duration(seconds: 1),
+                autoPlayAnimationDuration: Duration(milliseconds: 200),
+                viewportFraction: 1.0,
+                enableInfiniteScroll: false,
+                pauseAutoPlayInFiniteScroll: false,
+              ),
+              onPageChanged: (index, reason) {
+                lastPageIndex = index;
+              },
+              items: const [
+                Text('Item 1'),
+                Text('Item 2'),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      // Auto play to last item (Item 2)
+      await tester.pump(const Duration(seconds: 1));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(lastPageIndex, 1);
+
+      // Wait another interval - should wrap to Item 1
+      await tester.pump(const Duration(seconds: 1));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(lastPageIndex, 0);
+    });
+  });
+
+  group('animateToClosest option', () {
+    testWidgets('when false, does not search for closest path',
+        (tester) async {
+      final controller = CarouselControllerX();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CarouselSlider(
+              carouselController: controller,
+              options: const CarouselOptions(
+                enableInfiniteScroll: true,
+                initialPage: 0,
+                animateToClosest: false,
+              ),
+              items: const [
+                Text('1'),
+                Text('2'),
+                Text('3'),
+                Text('4'),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      // With animateToClosest: false, it should still navigate correctly
+      controller.animateToPage(3);
+      await tester.pumpAndSettle();
+      expect(find.text('4'), findsOneWidget);
+    });
+
+    testWidgets(
+        'when true, chooses backward wrap when it is the shortest path',
+        (tester) async {
+      // Regression: duplicate condition bug caused backward wrap to never
+      // be selected. With 10 items at page 1, animateToPage(9) should go
+      // backward 2 steps (1->0->9) instead of forward 8 steps (1->2->...->9).
+      final controller = CarouselControllerX();
+      int? lastChangedIndex;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CarouselSlider(
+              carouselController: controller,
+              options: const CarouselOptions(
+                enableInfiniteScroll: true,
+                initialPage: 1,
+                animateToClosest: true,
+                viewportFraction: 1.0,
+              ),
+              onPageChanged: (index, reason) {
+                lastChangedIndex = index;
+              },
+              items: List.generate(10, (i) => Text('P$i')),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('P1'), findsOneWidget);
+
+      controller.animateToPage(9);
+      await tester.pumpAndSettle();
+
+      expect(lastChangedIndex, 9);
+      expect(find.text('P9'), findsOneWidget);
+    });
+  });
+
+  group('Enlarge Strategies', () {
+    testWidgets('Scale strategy renders with Transform.scale',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CarouselSlider(
+              options: const CarouselOptions(
+                viewportFraction: 0.7,
+                enlargeCenterPage: true,
+                enlargeStrategy: CenterPageEnlargeStrategy.scale,
+                initialPage: 1,
+                enableInfiniteScroll: false,
+              ),
+              items: const [
+                Text('Item 0'),
+                Text('Item 1'),
+                Text('Item 2'),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      // Center item (Item 1) should exist with Transform
+      final item1TransformFinder = find
+          .ancestor(
+              of: find.text('Item 1'), matching: find.byType(Transform))
+          .first;
+      final transform1 = tester.widget<Transform>(item1TransformFinder);
+      final scale1 = transform1.transform.storage[0];
+
+      expect(scale1, closeTo(1.0, 0.01));
+
+      // Side items should have SizedBox for width/height constraint
+      expect(find.byType(SizedBox), findsWidgets);
+    });
+
+    testWidgets('Horizontal zoom strategy uses correct alignment',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CarouselSlider(
+              options: const CarouselOptions(
+                scrollDirection: Axis.horizontal,
+                viewportFraction: 0.7,
+                enlargeCenterPage: true,
+                enlargeStrategy: CenterPageEnlargeStrategy.zoom,
+                initialPage: 1,
+                enableInfiniteScroll: false,
+              ),
+              items: const [
+                Text('Item 0'),
+                Text('Item 1'),
+                Text('Item 2'),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      // Verify the Transform exists and renders
+      expect(find.byType(Transform), findsWidgets);
+      expect(find.text('Item 1'), findsOneWidget);
+    });
+  });
+
+  group('Layout options', () {
+    testWidgets('uses AspectRatio when height is null', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CarouselSlider(
+              options: const CarouselOptions(
+                aspectRatio: 2.0,
+                enableInfiniteScroll: false,
+              ),
+              items: const [Text('1')],
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(AspectRatio), findsOneWidget);
+      final aspectRatio = tester.widget<AspectRatio>(find.byType(AspectRatio));
+      expect(aspectRatio.aspectRatio, 2.0);
+    });
+
+    testWidgets('uses SizedBox with explicit height', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CarouselSlider(
+              options: const CarouselOptions(
+                height: 250,
+                enableInfiniteScroll: false,
+              ),
+              items: const [Text('1')],
+            ),
+          ),
+        ),
+      );
+
+      // Should not use AspectRatio when height is provided
+      // The outermost SizedBox should have height 250
+      final sizedBoxes = tester
+          .widgetList<SizedBox>(find.byType(SizedBox))
+          .where((sb) => sb.height == 250);
+      expect(sizedBoxes, isNotEmpty);
+    });
+  });
+
+  group('disableCenter', () {
+    testWidgets('when true, Center widget is not added', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CarouselSlider(
+              options: const CarouselOptions(
+                disableCenter: true,
+                enableInfiniteScroll: false,
+              ),
+              items: const [Text('Item 1')],
+            ),
+          ),
+        ),
+      );
+
+      // Center should not wrap the item text
+      expect(
+        find.ancestor(
+          of: find.text('Item 1'),
+          matching: find.byType(Center),
+        ),
+        findsNothing,
+      );
+    });
+
+    testWidgets('when false, Center widget wraps each item', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CarouselSlider(
+              options: const CarouselOptions(
+                disableCenter: false,
+                enableInfiniteScroll: false,
+              ),
+              items: const [Text('Item 1')],
+            ),
+          ),
+        ),
+      );
+
+      expect(
+        find.ancestor(
+          of: find.text('Item 1'),
+          matching: find.byType(Center),
+        ),
+        findsOneWidget,
+      );
+    });
+  });
+
+  group('reverse option', () {
+    testWidgets('PageView has reverse property set', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CarouselSlider(
+              options: const CarouselOptions(
+                reverse: true,
+                enableInfiniteScroll: false,
+              ),
+              items: const [Text('1'), Text('2')],
+            ),
+          ),
+        ),
+      );
+
+      final pageView = tester.widget<PageView>(find.byType(PageView));
+      expect(pageView.reverse, isTrue);
+    });
+
+    testWidgets('PageView reverse is false by default', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CarouselSlider(
+              options: const CarouselOptions(
+                enableInfiniteScroll: false,
+              ),
+              items: const [Text('1'), Text('2')],
+            ),
+          ),
+        ),
+      );
+
+      final pageView = tester.widget<PageView>(find.byType(PageView));
+      expect(pageView.reverse, isFalse);
+    });
+  });
+
+  group('Vertical scrolling', () {
+    testWidgets('scrolls vertically', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CarouselSlider(
+              options: const CarouselOptions(
+                scrollDirection: Axis.vertical,
+                viewportFraction: 1.0,
+                enableInfiniteScroll: false,
+                height: 400,
+              ),
+              items: const [
+                Text('Item 1'),
+                Text('Item 2'),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Item 1'), findsOneWidget);
+
+      // Fling vertically (upward)
+      await tester.fling(find.text('Item 1'), const Offset(0, -500), 2000);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Item 2'), findsOneWidget);
+    });
+
+    testWidgets('PageView has vertical scroll direction', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CarouselSlider(
+              options: const CarouselOptions(
+                scrollDirection: Axis.vertical,
+                enableInfiniteScroll: false,
+                height: 400,
+              ),
+              items: const [Text('1'), Text('2')],
+            ),
+          ),
+        ),
+      );
+
+      final pageView = tester.widget<PageView>(find.byType(PageView));
+      expect(pageView.scrollDirection, Axis.vertical);
+    });
+  });
+
+  group('didUpdateWidget', () {
+    testWidgets('updates page controller when initialPage changes',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CarouselSlider(
+              key: const ValueKey('carousel'),
+              options: const CarouselOptions(
+                initialPage: 0,
+                viewportFraction: 1.0,
+                enableInfiniteScroll: false,
+              ),
+              items: const [Text('1'), Text('2'), Text('3')],
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('1'), findsOneWidget);
+
+      // Update with new initialPage
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CarouselSlider(
+              key: const ValueKey('carousel'),
+              options: const CarouselOptions(
+                initialPage: 2,
+                viewportFraction: 1.0,
+                enableInfiniteScroll: false,
+              ),
+              items: const [Text('1'), Text('2'), Text('3')],
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      expect(find.text('3'), findsOneWidget);
+    });
+
+    testWidgets('handles autoPlay toggle via options update', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CarouselSlider(
+              key: const ValueKey('carousel'),
+              options: const CarouselOptions(
+                autoPlay: false,
+                viewportFraction: 1.0,
+                enableInfiniteScroll: false,
+              ),
+              items: const [Text('1'), Text('2')],
+            ),
+          ),
+        ),
+      );
+
+      // Enable auto play
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CarouselSlider(
+              key: const ValueKey('carousel'),
+              options: const CarouselOptions(
+                autoPlay: true,
+                autoPlayInterval: Duration(seconds: 1),
+                autoPlayAnimationDuration: Duration(milliseconds: 200),
+                viewportFraction: 1.0,
+                enableInfiniteScroll: false,
+              ),
+              items: const [Text('1'), Text('2')],
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('1'), findsOneWidget);
+
+      // Wait for auto play
+      await tester.pump(const Duration(seconds: 1));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(find.text('2'), findsOneWidget);
+    });
+  });
+
+  group('PageView passthrough options', () {
+    testWidgets('padEnds is forwarded to PageView', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CarouselSlider(
+              options: const CarouselOptions(
+                padEnds: false,
+                enableInfiniteScroll: false,
+              ),
+              items: const [Text('1'), Text('2')],
+            ),
+          ),
+        ),
+      );
+
+      final pageView = tester.widget<PageView>(find.byType(PageView));
+      expect(pageView.padEnds, isFalse);
+    });
+
+    testWidgets('padEnds defaults to true', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CarouselSlider(
+              options: const CarouselOptions(
+                enableInfiniteScroll: false,
+              ),
+              items: const [Text('1'), Text('2')],
+            ),
+          ),
+        ),
+      );
+
+      final pageView = tester.widget<PageView>(find.byType(PageView));
+      expect(pageView.padEnds, isTrue);
+    });
+
+    testWidgets('clipBehavior is forwarded to PageView', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CarouselSlider(
+              options: const CarouselOptions(
+                clipBehavior: Clip.none,
+                enableInfiniteScroll: false,
+              ),
+              items: const [Text('1'), Text('2')],
+            ),
+          ),
+        ),
+      );
+
+      final pageView = tester.widget<PageView>(find.byType(PageView));
+      expect(pageView.clipBehavior, Clip.none);
+    });
+
+    testWidgets('clipBehavior defaults to Clip.hardEdge', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CarouselSlider(
+              options: const CarouselOptions(
+                enableInfiniteScroll: false,
+              ),
+              items: const [Text('1'), Text('2')],
+            ),
+          ),
+        ),
+      );
+
+      final pageView = tester.widget<PageView>(find.byType(PageView));
+      expect(pageView.clipBehavior, Clip.hardEdge);
+    });
+
+    testWidgets('pageSnapping is forwarded to PageView', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CarouselSlider(
+              options: const CarouselOptions(
+                pageSnapping: false,
+                enableInfiniteScroll: false,
+              ),
+              items: const [Text('1'), Text('2')],
+            ),
+          ),
+        ),
+      );
+
+      final pageView = tester.widget<PageView>(find.byType(PageView));
+      expect(pageView.pageSnapping, isFalse);
+    });
+
+    testWidgets('pageSnapping defaults to true', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CarouselSlider(
+              options: const CarouselOptions(
+                enableInfiniteScroll: false,
+              ),
+              items: const [Text('1'), Text('2')],
+            ),
+          ),
+        ),
+      );
+
+      final pageView = tester.widget<PageView>(find.byType(PageView));
+      expect(pageView.pageSnapping, isTrue);
+    });
+  });
+
+  group('CarouselControllerX dispose safety', () {
+    test('methods do not throw after dispose', () {
+      final controller = CarouselControllerX();
+      controller.dispose();
+
+      // All methods should be safe to call after dispose (callbacks are null)
+      expect(() => controller.nextPage(), returnsNormally);
+      expect(() => controller.previousPage(), returnsNormally);
+      expect(() => controller.jumpToPage(0), returnsNormally);
+      expect(() => controller.animateToPage(0), returnsNormally);
+      expect(() => controller.startAutoPlay(), returnsNormally);
+      expect(() => controller.stopAutoPlay(), returnsNormally);
     });
   });
 }


### PR DESCRIPTION
Fix duplicate condition in animateToClosest that prevented backward wrap path from ever being selected. Add 28 new tests covering all previously untested options and logic branches.